### PR TITLE
SwapsSteward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ test-rates-factory:; forge test -vvv --match-path src/test/V3RateStrategyFactory
 test-v2-config-engine:; forge test -vvv --match-path src/test/AaveV2ConfigEngineTest.t.sol --gas-report
 test-v2-rates-factory:; forge test -vvv --match-path src/test/V2RateStrategyFactory.t.sol --gas-report
 test-financesteward:; forge test -vvv --match-path tests/financestewards/FinanceSteward.t.sol
-test-poolv3-steward:; forge test -vvv --match-path tests/financestewards/PoolV3FinSteward.t.sol 
+test-poolv3-steward:; forge test -vvv --match-path tests/financestewards/PoolV3FinSteward.t.sol
+test-swap-steward:; forge test -vvv --match-path tests/financestewards/SwapSteward.t.sol
 
 # Scripts
 deploy-engine-eth :;  forge script scripts/AaveV3ConfigEngine.s.sol:DeployEngineEth --rpc-url mainnet --broadcast --legacy --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify -vvvv

--- a/src/financestewards/FinanceSteward.sol
+++ b/src/financestewards/FinanceSteward.sol
@@ -5,7 +5,7 @@ import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
 import {SafeERC20} from 'solidity-utils/contracts/oz-common/SafeERC20.sol';
 import {OwnableWithGuardian} from 'solidity-utils/contracts/access-control/OwnableWithGuardian.sol';
 import {ICollector, CollectorUtils as CU} from '../CollectorUtils.sol';
-import {IFinanceSteward} from './IFinanceSteward.sol';
+import {IFinanceSteward} from './interfaces/IFinanceSteward.sol';
 
 /**
  * @title FinanceSteward

--- a/src/financestewards/PoolV3FinSteward.sol
+++ b/src/financestewards/PoolV3FinSteward.sol
@@ -9,7 +9,7 @@ import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethe
 import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
 import {IPool, DataTypes as DataTypesV3} from 'aave-address-book/AaveV3.sol';
 import {ILendingPool, DataTypes as DataTypesV2} from 'aave-address-book/AaveV2.sol';
-import {IPoolV3FinSteward} from './IPoolV3FinSteward.sol';
+import {IPoolV3FinSteward} from './interfaces/IPoolV3FinSteward.sol';
 
 /**
  * @title PoolV3FinSteward
@@ -107,6 +107,16 @@ contract PoolV3FinSteward is OwnableWithGuardian, IPoolV3FinSteward {
     CU.withdrawFromV2(COLLECTOR, withdrawData, address(COLLECTOR));
   }
 
+  /// @inheritdoc IPoolV3FinSteward
+  function validateAmount(address token, uint256 amount) external view {
+    _validateAmount(token, amount);
+  }
+
+  /// @inheritdoc IPoolV3FinSteward
+  function validateV3Pool(address pool) external view {
+    _validateV3Pool(pool);
+  }
+
   /// DAO Actions
 
   /// @inheritdoc IPoolV3FinSteward
@@ -144,13 +154,15 @@ contract PoolV3FinSteward is OwnableWithGuardian, IPoolV3FinSteward {
     if (v3Pools[pool] == false) revert UnrecognizedV3Pool();
   }
 
-  function _validateAmount(address token, uint256 amount) internal view returns (uint256 validAmount) {
+  /// @dev Internal function to validate minimum-amount to be left in a reserve
+  function _validateAmount(address token, uint256 amount) internal view returns (uint256) {
     uint256 balance = IERC20(token).balanceOf(address(COLLECTOR));
     if (minTokenBalance[token] > 0) {
       uint256 leftover = (amount > balance) ? 0 : balance - amount;
 
       if (minTokenBalance[token] > leftover) revert MinimumBalanceShield(minTokenBalance[token]);
     }
-    validAmount = (amount > balance) ? balance : amount;
+
+    return (amount > balance) ? balance : amount;
   }
 }

--- a/src/financestewards/SwapSteward.sol
+++ b/src/financestewards/SwapSteward.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+import {SafeERC20} from 'solidity-utils/contracts/oz-common/SafeERC20.sol';
+import {OwnableWithGuardian} from 'solidity-utils/contracts/access-control/OwnableWithGuardian.sol';
+import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+import {IPool, DataTypes as DataTypesV3} from 'aave-address-book/AaveV3.sol';
+import {ILendingPool, DataTypes as DataTypesV2} from 'aave-address-book/AaveV2.sol';
+
+import {AaveSwapper} from 'src/swaps/AaveSwapper.sol';
+import {AggregatorInterface} from 'src/financestewards/AggregatorInterface.sol';
+import {ICollector, CollectorUtils as CU} from 'src/CollectorUtils.sol';
+import {IPoolV3FinSteward} from 'src/financestewards/interfaces/IPoolV3FinSteward.sol';
+import {ISwapSteward} from 'src/financestewards/interfaces/ISwapSteward.sol';
+
+contract SwapSteward is OwnableWithGuardian, ISwapSteward {
+  using DataTypesV2 for DataTypesV2.ReserveData;
+  using DataTypesV3 for DataTypesV3.ReserveDataLegacy;
+  using CU for CU.SwapInput;
+
+  /// @inheritdoc ISwapSteward
+  uint256 public constant MAX_SLIPPAGE = 1000; // 10%
+
+  /// @inheritdoc ISwapSteward
+  AaveSwapper public immutable SWAPPER = AaveSwapper(MiscEthereum.AAVE_SWAPPER);
+
+  /// @inheritdoc ISwapSteward
+  ICollector public immutable COLLECTOR = AaveV3Ethereum.COLLECTOR;
+
+  /// @inheritdoc ISwapSteward
+  IPoolV3FinSteward public POOLV3STEWARD;
+
+  /// @inheritdoc ISwapSteward
+  address public MILKMAN;
+
+  /// @inheritdoc ISwapSteward
+  address public PRICE_CHECKER;
+
+  /// @inheritdoc ISwapSteward
+  mapping(address token => bool isApproved) public swapApprovedToken;
+
+  /// @inheritdoc ISwapSteward
+  mapping(address token => address oracle) public priceOracle;
+
+  constructor(address _owner, address _guardian, address _poolV3Steward) {
+    _transferOwnership(_owner);
+    _updateGuardian(_guardian);
+
+    // https://etherscan.io/address/0x060373D064d0168931dE2AB8DDA7410923d06E88
+    _setMilkman(0x060373D064d0168931dE2AB8DDA7410923d06E88);
+
+    // https://etherscan.io/address/0xe80a1C615F75AFF7Ed8F08c9F21f9d00982D666c
+    _setPriceChecker(0xe80a1C615F75AFF7Ed8F08c9F21f9d00982D666c);
+    _setPoolV3Steward(_poolV3Steward);
+  }
+
+  /// @inheritdoc ISwapSteward
+  function withdrawV2andSwap(
+    address reserve,
+    uint256 amount,
+    address buyToken,
+    uint256 slippage
+  ) external onlyOwnerOrGuardian {
+    DataTypesV2.ReserveData memory reserveData = POOLV3STEWARD.v2Pool().getReserveData(reserve);
+
+    POOLV3STEWARD.validateAmount(reserveData.aTokenAddress, amount);
+    _validateSwap(reserve, amount, buyToken, slippage);
+
+    CU.IOInput memory withdrawData = CU.IOInput(address(POOLV3STEWARD.v2Pool()), reserve, amount);
+
+    uint256 withdrawAmount = CU.withdrawFromV2(COLLECTOR, withdrawData, address(this));
+
+    CU.SwapInput memory swapData = CU.SwapInput(
+      MILKMAN,
+      PRICE_CHECKER,
+      reserve,
+      buyToken,
+      priceOracle[reserve],
+      priceOracle[buyToken],
+      withdrawAmount,
+      slippage
+    );
+
+    CU.swap(COLLECTOR, address(SWAPPER), swapData);
+  }
+
+  /// @inheritdoc ISwapSteward
+  function withdrawV3andSwap(
+    address pool,
+    address reserve,
+    uint256 amount,
+    address buyToken,
+    uint256 slippage
+  ) external onlyOwnerOrGuardian {
+    POOLV3STEWARD.validateV3Pool(pool);
+
+    DataTypesV3.ReserveDataLegacy memory reserveData = IPool(pool).getReserveData(reserve);
+
+    POOLV3STEWARD.validateAmount(reserveData.aTokenAddress, amount);
+    _validateSwap(reserve, amount, buyToken, slippage);
+
+    CU.IOInput memory withdrawData = CU.IOInput(pool, reserve, amount);
+
+    uint256 withdrawAmount = CU.withdrawFromV3(COLLECTOR, withdrawData, address(this));
+
+    CU.SwapInput memory swapData = CU.SwapInput(
+      MILKMAN,
+      PRICE_CHECKER,
+      reserve,
+      buyToken,
+      priceOracle[reserve],
+      priceOracle[buyToken],
+      withdrawAmount,
+      slippage
+    );
+
+    CU.swap(COLLECTOR, address(SWAPPER), swapData);
+  }
+
+  /// @inheritdoc ISwapSteward
+  function tokenSwap(
+    address sellToken,
+    uint256 amount,
+    address buyToken,
+    uint256 slippage
+  ) external onlyOwnerOrGuardian {
+    POOLV3STEWARD.validateAmount(sellToken, amount);
+    _validateSwap(sellToken, amount, buyToken, slippage);
+
+    CU.SwapInput memory swapData = CU.SwapInput(
+      MILKMAN,
+      PRICE_CHECKER,
+      sellToken,
+      buyToken,
+      priceOracle[sellToken],
+      priceOracle[buyToken],
+      amount,
+      slippage
+    );
+
+    CU.swap(COLLECTOR, address(SWAPPER), swapData);
+  }
+
+  /// @inheritdoc ISwapSteward
+  function setSwappableToken(address token, address priceFeedUSD) external onlyOwner {
+    if (priceFeedUSD == address(0)) revert MissingPriceFeed();
+
+    swapApprovedToken[token] = true;
+    priceOracle[token] = priceFeedUSD;
+
+    // Validate oracle has necessary functions
+    AggregatorInterface(priceFeedUSD).decimals();
+    AggregatorInterface(priceFeedUSD).latestAnswer();
+
+    emit SwapApprovedToken(token, priceFeedUSD);
+  }
+
+  function setPoolV3Steward(address newPoolV3Steward) external onlyOwner {
+    _setPoolV3Steward(newPoolV3Steward);
+  }
+
+  /// @inheritdoc ISwapSteward
+  function setPriceChecker(address newPriceChecker) external onlyOwner {
+    _setPriceChecker(newPriceChecker);
+  }
+
+  /// @inheritdoc ISwapSteward
+  function setMilkman(address newMilkman) external onlyOwner {
+    _setMilkman(newMilkman);
+  }
+
+  /// @dev Internal function to set the PoolV3FinSteward
+  function _setPoolV3Steward(address poolV3Steward) internal {
+    if (poolV3Steward == address(0)) revert InvalidZeroAddress();
+    POOLV3STEWARD = IPoolV3FinSteward(poolV3Steward);
+  }
+
+  /// @dev Internal function to set the price checker
+  function _setPriceChecker(address newPriceChecker) internal {
+    if (newPriceChecker == address(0)) revert InvalidZeroAddress();
+    PRICE_CHECKER = newPriceChecker;
+  }
+
+  /// @dev Internal function to set the Milkman instance address
+  function _setMilkman(address newMilkman) internal {
+    if (newMilkman == address(0)) revert InvalidZeroAddress();
+    address old = MILKMAN;
+    MILKMAN = newMilkman;
+
+    emit MilkmanAddressUpdated(old, newMilkman);
+  }
+
+  /// @dev Internal function to validate a swap's parameters
+  function _validateSwap(
+    address sellToken,
+    uint256 amountIn,
+    address buyToken,
+    uint256 slippage
+  ) internal view {
+    if (amountIn == 0) revert InvalidZeroAmount();
+
+    if (!swapApprovedToken[sellToken] || !swapApprovedToken[buyToken]) {
+      revert UnrecognizedToken();
+    }
+
+    if (slippage > MAX_SLIPPAGE) revert InvalidSlippage();
+
+    if (
+      AggregatorInterface(priceOracle[buyToken]).latestAnswer() == 0 ||
+      AggregatorInterface(priceOracle[sellToken]).latestAnswer() == 0
+    ) {
+      revert PriceFeedFailure();
+    }
+  }
+}

--- a/src/financestewards/interfaces/IFinanceSteward.sol
+++ b/src/financestewards/interfaces/IFinanceSteward.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ICollector} from '../CollectorUtils.sol';
+import {ICollector} from '../../CollectorUtils.sol';
 import {IPool} from 'aave-address-book/AaveV3.sol';
 import {ILendingPool} from 'aave-address-book/AaveV2.sol';
 
@@ -137,5 +137,4 @@ interface IFinanceSteward {
   /// @param token The address of the token
   /// @param amount The minimum balance to shield
   function setMinimumBalanceShield(address token, uint amount) external;
-
 }

--- a/src/financestewards/interfaces/IPoolV3FinSteward.sol
+++ b/src/financestewards/interfaces/IPoolV3FinSteward.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ICollector} from '../CollectorUtils.sol';
+import {ICollector} from '../../CollectorUtils.sol';
 import {IPool} from 'aave-address-book/AaveV3.sol';
 import {ILendingPool} from 'aave-address-book/AaveV2.sol';
 
@@ -16,6 +16,7 @@ interface IPoolV3FinSteward {
   /// @dev Aave V3 Pool must have been previously approved
   error UnrecognizedV3Pool();
 
+  /// @dev Could not identify V2 Pool
   error V2PoolNotFound();
 
   /// @notice Emitted when a new V3 Pool gets listed
@@ -67,6 +68,15 @@ interface IPoolV3FinSteward {
   /// @param reserve The address of the reserve token to withdraw
   /// @param amount The amount of the reserve token to withdraw
   function withdrawV3(address V3Pool, address reserve, uint amount) external;
+
+  /// @notice Checks whether aToken amount can be withdrawn from a reserve
+  /// @param token Address of the Aave Token
+  /// @param amount The amount to withdraw from the reserve
+  function validateAmount(address token, uint256 amount) external view;
+
+  /// @notice Checks whether a V3 pool instance is configured to be interacted with
+  /// @param pool Address of the V3 pool to check
+  function validateV3Pool(address pool) external view;
 
   /// @notice Sets the minimum balance shield for a specified token
   /// @param token The address of the token

--- a/src/financestewards/interfaces/ISwapSteward.sol
+++ b/src/financestewards/interfaces/ISwapSteward.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ICollector} from '../../CollectorUtils.sol';
+import {IPoolV3FinSteward} from './IPoolV3FinSteward.sol';
+import {AaveSwapper} from 'src/swaps/AaveSwapper.sol';
+
+interface ISwapSteward {
+  /// @dev Slippage is too high
+  error InvalidSlippage();
+
+  /// @dev Provided address cannot be the zero-address
+  error InvalidZeroAddress();
+
+  /// @dev Amount cannot be zero
+  error InvalidZeroAmount();
+
+  /// @dev Oracle cannot be the zero-address
+  error MissingPriceFeed();
+
+  /// @dev Oracle did not return a valid value
+  error PriceFeedFailure();
+
+  /// @dev Token has not been previously approved for swapping
+  error UnrecognizedToken();
+
+  /// @notice Emitted when the Milkman contract address is updated
+  /// @param oldAddress The old Milkman instance address
+  /// @param newAddress The new Milkman instance address
+  event MilkmanAddressUpdated(address oldAddress, address newAddress);
+
+  /// @notice Emitted when a token is approved for swapping with its corresponding USD oracle
+  /// @param token The address of the token approved for swapping
+  /// @param oracleUSD The address of the oracle providing the USD price feed for the token
+  event SwapApprovedToken(address indexed token, address indexed oracleUSD);
+
+  /// @notice Returns instance of Aave V3 Collector
+  function COLLECTOR() external view returns (ICollector);
+
+  /// @notice Returns instance of PoolV3FinSteward
+  function POOLV3STEWARD() external view returns (IPoolV3FinSteward);
+
+  /// @notice Returns the maximum allowed slippage for swaps (in BPS)
+  function MAX_SLIPPAGE() external view returns (uint256);
+
+  /// @notice Returns instance of the AaveSwapper contract
+  function SWAPPER() external view returns (AaveSwapper);
+
+  /// @notice Returns the address of the Milkman contract
+  function MILKMAN() external view returns (address);
+
+  /// @notice Returns address of the price checker used for swaps
+  function PRICE_CHECKER() external view returns (address);
+
+  /// @notice Returns whether token is approved to be swapped from/to
+  /// @param token Address of the token to swap from/to
+  function swapApprovedToken(address token) external view returns (bool);
+
+  /// @notice Returns address of the Oracle to use for token swaps
+  /// @param token Address of the token to swap
+  function priceOracle(address token) external view returns (address);
+
+  /// @notice Withdraws a specified amount of a reserve token from Aave V2 and swaps it for another token
+  /// @param reserve The address of the reserve token to withdraw
+  /// @param amount The amount of the reserve token to withdraw
+  /// @param buyToken The address of the token to buy with the withdrawn reserve token
+  /// @param slippage The slippage allowed in the swap
+  function withdrawV2andSwap(
+    address reserve,
+    uint amount,
+    address buyToken,
+    uint256 slippage
+  ) external;
+
+  /// @notice Withdraws a specified amount of a reserve token from Aave V3 and swaps it for another token
+  /// @param V3Pool The address of the V3 Pool to withdraw from
+  /// @param reserve The address of the reserve token to withdraw
+  /// @param amount The amount of the reserve token to withdraw
+  /// @param buyToken The address of the token to buy with the withdrawn reserve token
+  /// @param slippage The slippage allowed in the swap
+  function withdrawV3andSwap(
+    address V3Pool,
+    address reserve,
+    uint amount,
+    address buyToken,
+    uint256 slippage
+  ) external;
+
+  /// @notice Swaps a specified amount of a sell token for a buy token
+  /// @param sellToken The address of the token to sell
+  /// @param amount The amount of the sell token to swap
+  /// @param buyToken The address of the token to buy
+  /// @param slippage The slippage allowed in the swap
+  function tokenSwap(
+    address sellToken,
+    uint256 amount,
+    address buyToken,
+    uint256 slippage
+  ) external;
+
+  /// @notice Sets the address for the MILKMAN used in swaps
+  /// @param to The address of MILKMAN
+  function setMilkman(address to) external;
+
+  /// @notice Sets the address for the Price checker used in swaps
+  /// @param to The address of PRICE_CHECKER
+  function setPriceChecker(address to) external;
+
+  /// @notice Sets a token as swappable and provides its price feed address
+  /// @param token The address of the token to set as swappable
+  /// @param priceFeedUSD The address of the price feed for the token
+  function setSwappableToken(address token, address priceFeedUSD) external;
+}

--- a/tests/financestewards/SwapSteward.t.sol
+++ b/tests/financestewards/SwapSteward.t.sol
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import 'forge-std/Test.sol';
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {MiscEthereum} from 'aave-address-book/MiscEthereum.sol';
+import {Ownable} from 'solidity-utils/contracts/oz-common/Ownable.sol';
+import {ProxyAdmin} from 'solidity-utils/contracts/transparent-proxy/ProxyAdmin.sol';
+import {TransparentUpgradeableProxy} from 'solidity-utils/contracts/transparent-proxy/TransparentUpgradeableProxy.sol';
+import {ICollector} from 'collector-upgrade-rev6/lib/aave-v3-origin/src/contracts/treasury/ICollector.sol';
+import {Collector} from 'collector-upgrade-rev6/lib/aave-v3-origin/src/contracts/treasury/Collector.sol';
+import {IAccessControl} from 'aave-v3-origin/core/contracts/dependencies/openzeppelin/contracts/IAccessControl.sol';
+
+import {SwapSteward, ISwapSteward} from 'src/financestewards/SwapSteward.sol';
+import {PoolV3FinSteward, IPoolV3FinSteward} from 'src/financestewards/PoolV3FinSteward.sol';
+import {AggregatorInterface} from 'src/financestewards/AggregatorInterface.sol';
+import {CollectorUtils} from 'src/CollectorUtils.sol';
+
+/**
+ * @dev Test for SwapSteward contract
+ * command: make test-swap-steward
+ */
+contract SwapStewardTest is Test {
+  event SwapRequested(
+    address milkman,
+    address indexed fromToken,
+    address indexed toToken,
+    address fromOracle,
+    address toOracle,
+    uint256 amount,
+    address indexed recipient,
+    uint256 slippage
+  );
+  event SwapApprovedToken(address indexed token, address indexed oracleUSD);
+
+  address public alice = address(43);
+  address public constant guardian = address(82);
+  address public constant USDC_PRICE_FEED = 0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6;
+  address public constant AAVE_PRICE_FEED = 0x547a514d5e3769680Ce22B2361c10Ea13619e8a9;
+  address public constant EXECUTOR = 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A;
+  address public constant PROXY_ADMIN = 0xD3cF979e676265e4f6379749DECe4708B9A22476;
+  address public constant ACL_MANAGER = 0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0;
+
+  bytes32 public constant FUNDS_ADMIN_ROLE = 'FUNDS_ADMIN';
+
+  TransparentUpgradeableProxy public constant COLLECTOR_PROXY = TransparentUpgradeableProxy(payable(address(AaveV3Ethereum.COLLECTOR)));
+  ICollector collector = ICollector(address(COLLECTOR_PROXY));
+  PoolV3FinSteward public poolv3Steward;
+  SwapSteward public steward;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21353255);
+
+    Collector new_collector_impl = new Collector(ACL_MANAGER);
+    poolv3Steward = new PoolV3FinSteward(GovernanceV3Ethereum.EXECUTOR_LVL_1, guardian);
+    steward = new SwapSteward(GovernanceV3Ethereum.EXECUTOR_LVL_1, guardian, address(poolv3Steward));
+
+    vm.label(alice, "alice");
+    vm.label(guardian, "guardian");
+    vm.label(EXECUTOR, "EXECUTOR");
+    vm.label(address(AaveV3Ethereum.COLLECTOR), "Collector");
+    vm.label(address(steward), "SwapSteward");
+
+    vm.startPrank(EXECUTOR);
+
+    uint256 streamID = collector.getNextStreamId();
+
+    ProxyAdmin(PROXY_ADMIN).upgrade(COLLECTOR_PROXY, address(new_collector_impl));
+    IAccessControl(ACL_MANAGER).grantRole(FUNDS_ADMIN_ROLE, address(steward));
+    IAccessControl(ACL_MANAGER).grantRole(FUNDS_ADMIN_ROLE, EXECUTOR);
+    collector.initialize(streamID);
+
+    vm.stopPrank();
+
+    vm.prank(0x4B16c5dE96EB2117bBE5fd171E4d203624B014aa); //RANDOM USDC HOLDER
+    IERC20(AaveV3EthereumAssets.USDC_UNDERLYING).transfer(
+      address(AaveV3Ethereum.COLLECTOR),
+      1_000_000e6
+    );
+
+    vm.prank(EXECUTOR);
+    Ownable(MiscEthereum.AAVE_SWAPPER).transferOwnership(address(steward));
+  }
+}
+
+contract Function_withdrawV2andSwap is SwapStewardTest {
+  function test_revertsIf_notOwnerOrQuardian() public {
+    vm.startPrank(alice);
+
+    vm.expectRevert('ONLY_BY_OWNER_OR_GUARDIAN');
+    steward.withdrawV2andSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_zeroAmount() public {
+    vm.startPrank(guardian);
+
+    vm.expectRevert(ISwapSteward.InvalidZeroAmount.selector);
+    steward.withdrawV2andSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      0,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_minimumBalanceShield() public {
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    poolv3Steward.setMinimumBalanceShield(AaveV2EthereumAssets.USDC_A_TOKEN, 1_000e6);
+
+    vm.startPrank(guardian);
+
+    uint256 currentBalance = IERC20(AaveV2EthereumAssets.USDC_A_TOKEN).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(IPoolV3FinSteward.MinimumBalanceShield.selector, 1_000e6));
+    steward.withdrawV2andSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      currentBalance - 999e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_unrecognizedToken() public {
+    vm.startPrank(guardian);
+
+    vm.expectRevert(ISwapSteward.UnrecognizedToken.selector);
+    steward.withdrawV2andSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_success() public {
+    uint256 balanceV2Before = IERC20(AaveV2EthereumAssets.USDC_A_TOKEN).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+    uint256 slippage = 100;
+
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, USDC_PRICE_FEED);
+    steward.setSwappableToken(AaveV3EthereumAssets.AAVE_UNDERLYING, AAVE_PRICE_FEED);
+
+    vm.startPrank(guardian);
+    vm.expectEmit(true, true, true, true, address(steward.SWAPPER()));
+    emit SwapRequested(
+      steward.MILKMAN(),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      USDC_PRICE_FEED,
+      AAVE_PRICE_FEED,
+      1_000e6,
+      address(AaveV3Ethereum.COLLECTOR),
+      slippage
+    );
+
+    steward.withdrawV2andSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      slippage
+    );
+
+    assertLt(
+      IERC20(AaveV2EthereumAssets.USDC_A_TOKEN).balanceOf(address(AaveV3Ethereum.COLLECTOR)),
+      balanceV2Before
+    );
+
+    vm.stopPrank();
+  }
+}
+
+contract Function_withdrawV3andSwap is SwapStewardTest {
+  function test_revertsIf_notOwnerOrQuardian() public {
+    vm.startPrank(alice);
+
+    vm.expectRevert('ONLY_BY_OWNER_OR_GUARDIAN');
+    steward.withdrawV3andSwap(
+      address(AaveV3Ethereum.POOL),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_zeroAmount() public {
+    vm.startPrank(guardian);
+
+    vm.expectRevert(ISwapSteward.InvalidZeroAmount.selector);
+    steward.withdrawV3andSwap(
+      address(AaveV3Ethereum.POOL),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      0,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_minimumBalanceShield() public {
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    poolv3Steward.setMinimumBalanceShield(AaveV3EthereumAssets.USDC_A_TOKEN, 1_000e6);
+
+    vm.startPrank(guardian);
+
+    uint256 currentBalance = IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(IPoolV3FinSteward.MinimumBalanceShield.selector, 1_000e6));
+    steward.withdrawV3andSwap(
+      address(AaveV3Ethereum.POOL),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      currentBalance - 999e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_unrecognizedToken() public {
+    vm.startPrank(guardian);
+
+    vm.expectRevert(ISwapSteward.UnrecognizedToken.selector);
+    steward.withdrawV3andSwap(
+      address(AaveV3Ethereum.POOL),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_success() public {
+    uint256 balanceV3Before = IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+    uint256 slippage = 100;
+
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, USDC_PRICE_FEED);
+    steward.setSwappableToken(AaveV3EthereumAssets.AAVE_UNDERLYING, AAVE_PRICE_FEED);
+
+    vm.startPrank(guardian);
+    vm.expectEmit(true, true, true, true, address(steward.SWAPPER()));
+    emit SwapRequested(
+      steward.MILKMAN(),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      USDC_PRICE_FEED,
+      AAVE_PRICE_FEED,
+      1_000e6,
+      address(AaveV3Ethereum.COLLECTOR),
+      slippage
+    );
+
+    steward.withdrawV3andSwap(
+      address(AaveV3Ethereum.POOL),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      slippage
+    );
+
+    assertLt(
+      IERC20(AaveV3EthereumAssets.USDC_A_TOKEN).balanceOf(address(AaveV3Ethereum.COLLECTOR)),
+      balanceV3Before
+    );
+    vm.stopPrank();
+  }
+}
+
+contract Function_tokenSwap is SwapStewardTest {
+  function test_revertsIf_notOwnerOrQuardian() public {
+    vm.startPrank(alice);
+
+    vm.expectRevert('ONLY_BY_OWNER_OR_GUARDIAN');
+    steward.tokenSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_zeroAmount() public {
+    vm.startPrank(guardian);
+
+    vm.expectRevert(ISwapSteward.InvalidZeroAmount.selector);
+    steward.tokenSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      0,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_minimumBalanceShield() public {
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    poolv3Steward.setMinimumBalanceShield(AaveV3EthereumAssets.USDC_UNDERLYING, 1_000e6);
+
+    vm.startPrank(guardian);
+
+    uint256 currentBalance = IERC20(AaveV3EthereumAssets.USDC_UNDERLYING).balanceOf(
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+
+    vm.expectRevert(abi.encodeWithSelector(IPoolV3FinSteward.MinimumBalanceShield.selector, 1_000e6));
+    steward.tokenSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      currentBalance - 999e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_unrecognizedToken() public {
+    vm.startPrank(guardian);
+
+    vm.expectRevert(ISwapSteward.UnrecognizedToken.selector);
+    steward.tokenSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_invalidPriceFeedAnswer() public {
+    address mockOracle = address(new MockOracle());
+
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, mockOracle);
+    steward.setSwappableToken(
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      AaveV3EthereumAssets.AAVE_ORACLE
+    );
+
+    vm.startPrank(guardian);
+    vm.expectRevert(ISwapSteward.PriceFeedFailure.selector);
+    steward.tokenSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      100
+    );
+    vm.stopPrank();
+  }
+
+  function test_success() public {
+    uint256 slippage = 100;
+
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, USDC_PRICE_FEED);
+    steward.setSwappableToken(AaveV3EthereumAssets.AAVE_UNDERLYING, AAVE_PRICE_FEED);
+
+    vm.startPrank(guardian);
+    vm.expectEmit(true, true, true, true, address(steward.SWAPPER()));
+    emit SwapRequested(
+      steward.MILKMAN(),
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      USDC_PRICE_FEED,
+      AAVE_PRICE_FEED,
+      1_000e6,
+      address(AaveV3Ethereum.COLLECTOR),
+      slippage
+    );
+
+    steward.tokenSwap(
+      AaveV3EthereumAssets.USDC_UNDERLYING,
+      1_000e6,
+      AaveV3EthereumAssets.AAVE_UNDERLYING,
+      slippage
+    );
+    vm.stopPrank();
+  }
+}
+
+contract Function_setSwappableToken is SwapStewardTest {
+  function test_revertsIf_notOwner() public {
+    vm.startPrank(alice);
+    vm.expectRevert('Ownable: caller is not the owner');
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, USDC_PRICE_FEED);
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_missingPriceFeed() public {
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    vm.expectRevert(ISwapSteward.MissingPriceFeed.selector);
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, address(0));
+    vm.stopPrank();
+  }
+
+  function test_resvertsIf_incompatibleOracleMissingImplementations() public {
+    address mockOracle = address(new InvalidMockOracle());
+
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+    vm.expectRevert();
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, mockOracle);
+
+    vm.stopPrank();
+  }
+
+  function test_success() public {
+    vm.startPrank(GovernanceV3Ethereum.EXECUTOR_LVL_1);
+
+    vm.expectEmit(true, true, true, true, address(steward));
+    emit SwapApprovedToken(AaveV3EthereumAssets.USDC_UNDERLYING, USDC_PRICE_FEED);
+    steward.setSwappableToken(AaveV3EthereumAssets.USDC_UNDERLYING, USDC_PRICE_FEED);
+    vm.stopPrank();
+  }
+}
+
+/**
+ * Helper contract to mock price feed calls
+ */
+contract MockOracle {
+  function decimals() external pure returns (uint8) {
+    return 8;
+  }
+
+  function latestAnswer() external pure returns (int256) {
+    return 0;
+  }
+}
+
+/*
+ * Oracle missing `decimals` implementation thus invalid.
+ */
+contract InvalidMockOracle {
+  function latestAnswer() external pure returns (int256) {
+    return 0;
+  }
+}


### PR DESCRIPTION
# Changelog

Separate concerns from FinanceSteward into dedicated SwapsSteward to be deployed independently.

# TODO:

With this upgrade, I'd like to also do the following:

- AaveSwapper make the `swap()` function `onlyOwnerOrGuardian` and make the guardian the SwapsSteward.
- Allow SwapsSteward to `cancelSwap()`.